### PR TITLE
Fix/date conversions

### DIFF
--- a/Dashi/Dashi.xcodeproj/project.pbxproj
+++ b/Dashi/Dashi.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		A3CD1C801FABC8450061FEAB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A3CD1C7C1FABC8450061FEAB /* LaunchScreen.storyboard */; };
 		A3CD1C811FABC8450061FEAB /* Base.lproj in Resources */ = {isa = PBXBuildFile; fileRef = A3CD1C7E1FABC8450061FEAB /* Base.lproj */; };
 		A3FB0E4D1FAEB06E0023D212 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FB0E4C1FAEB06E0023D212 /* HomeViewController.swift */; };
+		D86D7481201E8E8000F62F4D /* DateConv.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86D7480201E8E8000F62F4D /* DateConv.swift */; };
 		D889C4261FC368280082052A /* DashiAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D889C4251FC368280082052A /* DashiAPI.swift */; };
 		D8FC2A59201A97EB00F3E532 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FC2A58201A97EB00F3E532 /* Account.swift */; };
 		D8FC2A5B201AA9B600F3E532 /* Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FC2A5A201AA9B600F3E532 /* Video.swift */; };
@@ -54,6 +55,7 @@
 		BE0E6449C1C4B632C49C8D03 /* Pods-Dashi.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Dashi.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Dashi/Pods-Dashi.debug.xcconfig"; sourceTree = "<group>"; };
 		D421366F3B5F63A7235F4A66 /* Pods-Dashi.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Dashi.release.xcconfig"; path = "Pods/Target Support Files/Pods-Dashi/Pods-Dashi.release.xcconfig"; sourceTree = "<group>"; };
 		D68B438EB114BBD623DF3819 /* Pods_Dashi.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Dashi.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D86D7480201E8E8000F62F4D /* DateConv.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateConv.swift; sourceTree = "<group>"; };
 		D889C4251FC368280082052A /* DashiAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashiAPI.swift; sourceTree = "<group>"; };
 		D8FC2A58201A97EB00F3E532 /* Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		D8FC2A5A201AA9B600F3E532 /* Video.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Video.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 				24A187D81FBBA568002615A8 /* DashiData.xcdatamodeld */,
 				A347FD881F9A9EAF0091973F /* AppDelegate.swift */,
 				A347FD941F9A9EAF0091973F /* Info.plist */,
+				D86D7480201E8E8000F62F4D /* DateConv.swift */,
 			);
 			path = SupportFiles;
 			sourceTree = "<group>";
@@ -319,6 +322,7 @@
 				A347FD891F9A9EAF0091973F /* AppDelegate.swift in Sources */,
 				2F0328EC1FC0E8AD00944477 /* PhotoManager.swift in Sources */,
 				A31F54111F9AD6F5007CD82F /* VideoViewController.swift in Sources */,
+				D86D7481201E8E8000F62F4D /* DateConv.swift in Sources */,
 				2F5B61101FA8D94000319291 /* VideosTableViewController.swift in Sources */,
 				A38A773E1F9D806D0004874F /* VideoPreviewViewController.swift in Sources */,
 				D8FC2A5B201AA9B600F3E532 /* Video.swift in Sources */,

--- a/Dashi/Dashi/Models/Account.swift
+++ b/Dashi/Dashi/Models/Account.swift
@@ -22,7 +22,7 @@ class Account {
     
     init(account: JSON) {
         self.fullName = account["fullName"].stringValue
-        self.created = Date().addingTimeInterval(account["created"].doubleValue)
+        self.created = DateConv.toDate(timestamp: account["created"].stringValue)
         self.id = account["id"].intValue
         self.email = account["email"].stringValue
     }

--- a/Dashi/Dashi/Models/Video.swift
+++ b/Dashi/Dashi/Models/Video.swift
@@ -28,8 +28,13 @@ class Video {
     }
     
     init(video: JSON) {
+<<<<<<< Updated upstream
         self.id = video["id"].intValue
         self.started = Date().addingTimeInterval(video["started"].doubleValue)
+=======
+        self.id = video["id"].string
+        self.started = DateConv.toDate(timestamp: video["started"].stringValue)
+>>>>>>> Stashed changes
         self.length = video["length"].intValue
         self.size = video["size"].intValue
     }

--- a/Dashi/Dashi/Models/Video.swift
+++ b/Dashi/Dashi/Models/Video.swift
@@ -28,13 +28,8 @@ class Video {
     }
     
     init(video: JSON) {
-<<<<<<< Updated upstream
         self.id = video["id"].intValue
-        self.started = Date().addingTimeInterval(video["started"].doubleValue)
-=======
-        self.id = video["id"].string
         self.started = DateConv.toDate(timestamp: video["started"].stringValue)
->>>>>>> Stashed changes
         self.length = video["length"].intValue
         self.size = video["size"].intValue
     }

--- a/Dashi/Dashi/SupportFiles/DateConv.swift
+++ b/Dashi/Dashi/SupportFiles/DateConv.swift
@@ -1,0 +1,35 @@
+//
+//  DateConv.swift
+//  Dashi
+//
+//  Created by Chris Henk on 1/28/18.
+//  Copyright © 2018 Senior Design. All rights reserved.
+//
+
+import Foundation
+
+struct DateConv {
+    
+    private static var dateFormatter: DateFormatter? = nil
+    
+    private static func initialize() {
+        self.dateFormatter = DateFormatter()
+        self.dateFormatter!.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    }
+    
+    public static func toDate(timestamp: String) -> Date {
+        if self.dateFormatter == nil {
+            self.initialize()
+        }
+        
+        return self.dateFormatter!.date(from: timestamp)!
+    }
+    
+    public static func toString(date: Date) -> String {
+        if self.dateFormatter == nil {
+            self.initialize()
+        }
+        
+        return self.dateFormatter!.string(from: date)
+    }
+}


### PR DESCRIPTION
This fixes a bug in how I was originally converting string timestamps to Swift Date objects. Swift doesn't have a pre-made formatter that supports the DB's timestamp format so I created an object that handles the boilerplate of configuring the DateFormatter object.